### PR TITLE
Add some links from the README to common docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,5 +2,7 @@
 
 Please [submit an issue](https://github.com/IBM/actionspz/issues) on this repo to access GitHub Actions on Power and Z.
 
+You can read more about on onboarding IBM Power and IBM Z to GitHub Actions in our [onboarding documentation](docs/onboarding.md). Other common questions can be answered in our [FAQ](docs/FAQ.md).
+
 ## Endianness
 Note that IBM Power (ppc64le) is little-endian and IBM Z (s390x) is big-endian.


### PR DESCRIPTION
I noticed that when the repo is the entrypoint, it's not clear where to go for more information. These links will guides users to onboarding and FAQ, which should get them where they need to go.

@mtarsel Please review.