### PR TITLE
Add compliance to TOS, etc to criteria

### DIFF
--- a/docs/criteria.md
+++ b/docs/criteria.md
@@ -28,3 +28,4 @@ These criteria define the minimum standards that any request to use **Actions fo
   - Documented upon request
 - **Preliminary validation work** on IBM architectures must be completed **prior to submitting an onboarding request**.
 
+It must be evident that the project will comply with the terms and restrictions in the [IBM Cloud Services Agreement](https://cloud.ibm.com/docs/overview?topic=overview-terms) and the Service Description for the Service.


### PR DESCRIPTION
Explicitly call out requirement to comply with terms and restrictions that IBM has in place for using our services.