### PR TITLE
Workflow, frequency updates to ISSUE template

### DIFF
--- a/.github/ISSUE_TEMPLATE/new-project-template.md
+++ b/.github/ISSUE_TEMPLATE/new-project-template.md
@@ -20,10 +20,13 @@ A clear and concise description of what the project is.
 **Describe the primary use case for the Github Action Runner**
 Example: We want to build go libraries for ppc64le. Or run lint tests on s390x.
 
-**Paste a link to the existing actions workflow file(s) or directory**
+**Paste a link to the existing actions workflow file(s), or directory with workflows, you wish to run on this service**
+Remember: You'll only want to run workflows that are required for test/build compatibility on ppc64le/s390x.
 
 **How often do you plan on executing the runner?**
 For example, every release or every commit.
+
+Details about how long your current workflows run are also helpful here.
 
 **What is the primary programming language for the project?**
 


### PR DESCRIPTION
For the new project issue template, we have found that we frequently have to follow-up with projects for more details about the specific workflows they want to run on our service, and their length. Include this in the template, and add note about being strategic about which workflows they specifically want to run on ppc64le/s390x.